### PR TITLE
add `9vx`/`vx32`

### DIFF
--- a/9vx/default.nix
+++ b/9vx/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchFromGitHub
+, multiStdenv
+, xorg
+, pkgsi686Linux
+}:
+
+let
+  repo = fetchFromGitHub {
+    owner = "9fans";
+    repo = "vx32";
+    rev = "6f3ef13b488e563c74b4fdb9c144eebe8aa4bfcf";
+    hash = "sha256-XBGXd+feO9H/k9MlKD6EvbVLFCfFSJnHQvl17aXqC+s=";
+  };
+in
+multiStdenv.mkDerivation {
+  pname = "_9vx";
+  version = "0.12";
+
+  nativeBuildInputs = [ xorg.libX11 pkgsi686Linux.xorg.libX11 ];
+
+  src = "${repo}/src";
+  makeFlags = [ "prefix=$(out)" ];
+  installPhase = ''
+    mkdir -p $out/bin
+    install 9vx/9vx $out/bin/9vx
+  '';
+
+  meta = with lib; {
+    homepage = "https://pdos.csail.mit.edu/~baford/vm/";
+    description = "Portable, efficient, safe execution of untrusted x86 code";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ moody _9glenda ];
+    platforms = platforms.unix;
+    mainProgram = "9vx";
+  };
+}

--- a/nine/default.nix
+++ b/nine/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+}:
+
+stdenv.mkDerivation {
+  pname = "nine";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "michaelforney";
+    repo = "nine";
+    rev = "c168349497922ab3f5afc7195089f20a529520cd";
+    hash = "sha256-rFtszVzUllTNNSYFMyanwytQdZnB7yWENbzjvJ3EVcQ=";
+  };
+  installPhase = ''
+    mkdir -p $out/bin
+    install nine $out/bin/nine
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/michaelforney/nine";
+    description = "wine for 9";
+    license = with licenses; [ unlicense ];
+    maintainers = with maintainers; [ moody _9glenda ];
+    platforms = platforms.unix;
+    mainProgram = "nine";
+  };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -37,7 +37,9 @@ let
 
   mame = { mame = prev.libsForQt5.callPackage (./mame) { }; };
 
-  pkgs = (builtins.listToAttrs (allvm ++ allsetup ++ allrun)) // mame;
+  _9vx = { _9vx = callPackage (./9vx) { }; };
+
+  pkgs = (builtins.listToAttrs (allvm ++ allsetup ++ allrun)) // mame // _9vx;
 in
 {
   vm9 = pkgs;

--- a/overlay.nix
+++ b/overlay.nix
@@ -39,7 +39,9 @@ let
 
   _9vx = { _9vx = callPackage (./9vx) { }; };
 
-  pkgs = (builtins.listToAttrs (allvm ++ allsetup ++ allrun)) // mame // _9vx;
+  nine = { nine = callPackage (./nine) { }; };
+
+  pkgs = (builtins.listToAttrs (allvm ++ allsetup ++ allrun)) // mame // _9vx // nine;
 in
 {
   vm9 = pkgs;


### PR DESCRIPTION
`9vx` is a binary emulator for linux allowing users to run plan9 binaries on linux. It also allows for extracting the 9front iso into a folder and running 9front from a folder on the linux file system.

Since `mame` is in the repo I thought it would be a good idea to add `9vx` too since it allows for some really cool grid networking.

I added you and myself as the maintainer of the package because I was not sure whom to put there.